### PR TITLE
Fix for conflicting dependencies

### DIFF
--- a/custom_components/exoy_one/manifest.json
+++ b/custom_components/exoy_one/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/Djelibeybi/hass-ExoyONE/issues",
   "loggers": ["exoyone"],
-  "requirements": ["pyExoyOne==0.1.3"],
+  "requirements": ["pyExoyOne>=0.1.3"],
   "version": "2024.8.2",
   "zeroconf": [
     {"type": "_http._tcp.local.", "name": "exoyone*"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ colorlog>=6.8.2
 homeassistant>=2024.6.0
 pip>=21.3.1
 ruff>=0.6.1
-pyExoyOne>=0.1.2
+pyExoyOne>=0.1.3


### PR DESCRIPTION
Logger: homeassistant.util.package
Source: util/package.py:123
First occurred: 20:47:17 (3 occurrences)
Last logged: 20:47:23
Unable to install package pyExoyOne==0.1.3: ERROR: Cannot install pyexoyone==0.1.3 because these package versions have conflicting dependencies. ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts