### PR TITLE
fix(light): is_on tracks emission, not fadingOff transition

### DIFF
--- a/custom_components/exoy_one/light.py
+++ b/custom_components/exoy_one/light.py
@@ -70,8 +70,9 @@ class ExoyOneLight(ExoyOneEntity, LightEntity):
 
     @property
     def is_on(self) -> bool:
-        """Return the state of the light."""
-        return self.coordinator.exoyone.state.fadingOff
+        """Return True if the light is currently emitting."""
+        state = self.coordinator.exoyone.state
+        return state.brightness > 0 and not state.fadingOff
 
     @property
     def brightness(self) -> int:


### PR DESCRIPTION
## Summary

`ExoyOneLight.is_on` returned `state.fadingOff` directly. That field reads `True` only DURING the fade-off transition, so the prior code inverted the user-perceived state in the common cases:

| Device state | `fadingOff` | prior `is_on` |
|---|---|---|
| Fully on    | `False` | ❌ `False` |
| Fully off   | `False` | ✓ `False` (by accident) |
| Fading off  | `True`  | ❌ `True`  |

Switch to `state.brightness > 0 and not state.fadingOff`. Brightness tracks emission directly; in-flight fade-off is treated as already off.

## Note to maintainer

If `state.brightness` does NOT zero on soft-off (only `fadingOff` flips), please suggest the canonical power-state field — happy to update this PR.

## Testing

Not device-tested by author — my setup uses a hardware switch upstream of the ExoyOne as the canonical on/off, so the integration's `is_on` is decorative for me. Logic verified by inspection against the `state` field references already in this file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the on/off status detection for Exoy One lights to account for both brightness levels and fading state, resulting in more accurate light status reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Djelibeybi/hass-ExoyONE/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->